### PR TITLE
Main script path fix (fixes #10)

### DIFF
--- a/scripts/AGSKill.bat
+++ b/scripts/AGSKill.bat
@@ -22,5 +22,6 @@ cd "C:\program files (x86)\common files\adobe\"
 mkdir "C:\program files (x86)\common files\adobe\AdobeGCClient"
 icacls "C:\program files (x86)\common files\adobe\AdobeGCClient" /deny Administrators:(F)
 
+cd %~dp0
 cd ..
 start CCStopper.bat


### PR DESCRIPTION
Fixed a path-related issue, where the "AGSKill.bat" sub-script wouldn't launch the main CCStopper script after executing.

Prevents the "Windows cannot find 'CCStopper.bat'. Make sure you typed the name correctly, and then try again." error (fixes #10).