### PR TITLE
Even more fixes

### DIFF
--- a/CCStopper.bat
+++ b/CCStopper.bat
@@ -84,7 +84,7 @@ cls
 if errorlevel 3 goto mainMenu
 
 if errorlevel 2 (
-	.\scripts\HideCCFiles.bat
+	.\scripts\HideCCFolder.bat
 	goto utilityMenu
 )
 

--- a/CCStopper.bat
+++ b/CCStopper.bat
@@ -20,7 +20,7 @@ echo          ^|      __________________________________________________________
 echo          ^|                                                                               ^|
 echo          ^|                                SAVE YOUR FILES!                               ^|
 echo          ^|                                                                               ^|
-echo          ^|      Stopping Adobe Processes will also close apps like Photohsop or          ^|
+echo          ^|      Stopping Adobe Processes will also close apps like Photoshop or          ^|
 echo          ^|      Premiere.                                                                ^|
 echo          ^|      ___________________________________________________________________      ^|
 echo          ^|                                                                               ^|

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Please don't run any code here, unless you know *exactly* what you're doing. If 
 - Combined Credit Card Stop module and ServiceBlock module
   - Thanks to [@sh32devnull](https://github.com/sh32devnull) for ServiceBlock module
   - Adds Adobe IPs to hosts file and blocks Adobe Desktop Service in firewall
-- Added DisableAutoStart, HideCCFiles, and TrialRemove modules
+- Added DisableAutoStart, HideCCFolder, and HideTrialBanner modules
   - Thanks to [@ItsProfessional](https://github.com/ItsProfessional) for all these modules
 - Bug Fixes and Improvements
   - Again, big thanks to contributors mentioned above for helping!

--- a/scripts/DisableAutoStart.ps1
+++ b/scripts/DisableAutoStart.ps1
@@ -1,16 +1,15 @@
-$myWindowsID=[System.Security.Principal.WindowsIdentity]::GetCurrent()
-$myWindowsPrincipal=new-object System.Security.Principal.WindowsPrincipal($myWindowsID)
-$adminRole=[System.Security.Principal.WindowsBuiltInRole]::Administrator
+$MyWindowsID=[System.Security.Principal.WindowsIdentity]::GetCurrent()
+$MyWindowsPrincipal=New-Object System.Security.Principal.WindowsPrincipal($MyWindowsID)
+$AdminRole=[System.Security.Principal.WindowsBuiltInRole]::Administrator
 
-if($myWindowsPrincipal.IsInRole($adminRole)) {
-$Host.UI.RawUI.WindowTitle = $myInvocation.MyCommand.Definition + "(Elevated)"
+if($MyWindowsPrincipal.IsInRole($AdminRole)) {
+$Host.UI.RawUI.WindowTitle = $MyInvocation.MyCommand.Definition + "(Elevated)"
    Clear-Host
 } else {
    $NewProcess = New-Object System.Diagnostics.ProcessStartInfo "PowerShell";
-   $NewProcess.Arguments = $myInvocation.MyCommand.Definition;
+   $NewProcess.Arguments = $MyInvocation.MyCommand.Definition;
    $NewProcess.Verb = "runas";
    [System.Diagnostics.Process]::Start($newProcess);
-
    exit
 }
 

--- a/scripts/HideCCFolder.bat
+++ b/scripts/HideCCFolder.bat
@@ -30,7 +30,7 @@ if %data% EQU 0 (
 	echo                  ^|                                                               ^|
 	echo                  ^|                            CCSTOPPER                          ^|
 	echo                  ^|                         Made by eaaasun                       ^|
-	echo                  ^|                        HideCCFiles Module                     ^|
+	echo                  ^|                        HideCCFolder Module                    ^|
 	echo                  ^|      ___________________________________________________      ^|
 	echo                  ^|                                                               ^|
 	echo                  ^|          CREATIVE CLOUD FILES FOLDER ALREADY HIDDEN!          ^|
@@ -101,7 +101,7 @@ if errorlevel 2 (
 )
 if errorlevel 1 (
 	echo Creating system restore point, please be patient.
-	wmic /Namespace:\\root\default Path SystemRestore Call CreateRestorePoint "Before CCStopper Hide CC Files Script", 100, 12
+	wmic /Namespace:\\root\default Path SystemRestore Call CreateRestorePoint "Before CCStopper Hide CC Folder Script", 100, 12
 	goto editReg
 )
 
@@ -132,7 +132,7 @@ echo                  ^|                                                        
 echo                  ^|                                                               ^|
 echo                  ^|                            CCSTOPPER                          ^|
 echo                  ^|                         Made by eaaasun                       ^|
-echo                  ^|                          HideCCF Module                       ^|
+echo                  ^|                          HideCCFolder Module                  ^|
 echo                  ^|      ___________________________________________________      ^|
 echo                  ^|                                                               ^|
 echo                  ^|                Hiding CCF from explorer complete!             ^|

--- a/scripts/HideTrialBanner.ps1
+++ b/scripts/HideTrialBanner.ps1
@@ -1,18 +1,18 @@
-$myWindowsID=[System.Security.Principal.WindowsIdentity]::GetCurrent()
-$myWindowsPrincipal=new-object System.Security.Principal.WindowsPrincipal($myWindowsID)
-$adminRole=[System.Security.Principal.WindowsBuiltInRole]::Administrator
+$MyWindowsID=[System.Security.Principal.WindowsIdentity]::GetCurrent()
+$MyWindowsPrincipal=New-Object System.Security.Principal.WindowsPrincipal($MyWindowsID)
+$AdminRole=[System.Security.Principal.WindowsBuiltInRole]::Administrator
 
-if($myWindowsPrincipal.IsInRole($adminRole)) {
-$Host.UI.RawUI.WindowTitle = $myInvocation.MyCommand.Definition + "(Elevated)"
+if($MyWindowsPrincipal.IsInRole($AdminRole)) {
+$Host.UI.RawUI.WindowTitle = $MyInvocation.MyCommand.Definition + "(Elevated)"
    Clear-Host
 } else {
    $NewProcess = New-Object System.Diagnostics.ProcessStartInfo "PowerShell";
-   $NewProcess.Arguments = $myInvocation.MyCommand.Definition;
+   $NewProcess.Arguments = $MyInvocation.MyCommand.Definition;
    $NewProcess.Verb = "runas";
    [System.Diagnostics.Process]::Start($newProcess);
-
    exit
 }
+
 $PsAppLocation = (Get-ItemProperty -Path "HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\PHSP_23_3").InstallLocation
 $AiAppLocation = (Get-ItemProperty -Path "HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\ILST_26_2_1").InstallLocation
 $Button = $Shell.Popup($AppLocation, 0, "Trial Banner Hider", 0)

--- a/scripts/StopProcesses.ps1
+++ b/scripts/StopProcesses.ps1
@@ -1,16 +1,15 @@
-$myWindowsID=[System.Security.Principal.WindowsIdentity]::GetCurrent()
-$myWindowsPrincipal=new-object System.Security.Principal.WindowsPrincipal($myWindowsID)
-$adminRole=[System.Security.Principal.WindowsBuiltInRole]::Administrator
+$MyWindowsID=[System.Security.Principal.WindowsIdentity]::GetCurrent()
+$MyWindowsPrincipal=New-Object System.Security.Principal.WindowsPrincipal($MyWindowsID)
+$AdminRole=[System.Security.Principal.WindowsBuiltInRole]::Administrator
 
-if($myWindowsPrincipal.IsInRole($adminRole)) {
-$Host.UI.RawUI.WindowTitle = $myInvocation.MyCommand.Definition + "(Elevated)"
+if($MyWindowsPrincipal.IsInRole($AdminRole)) {
+$Host.UI.RawUI.WindowTitle = $MyInvocation.MyCommand.Definition + "(Elevated)"
    Clear-Host
 } else {
    $NewProcess = New-Object System.Diagnostics.ProcessStartInfo "PowerShell";
-   $NewProcess.Arguments = $myInvocation.MyCommand.Definition;
+   $NewProcess.Arguments = $MyInvocation.MyCommand.Definition;
    $NewProcess.Verb = "runas";
    [System.Diagnostics.Process]::Start($newProcess);
-
    exit
 }
 


### PR DESCRIPTION
- Fix typo "photo**hs**op" in CCStopper.bat
- Rename HideCCFiles.bat to HideCCFolder.bat
- Update module names in README.md
  -  It was using the old names of modules
- Fix casing of the "ask for admin perms" code block in powershell scripts
  -  Unlike batch, in PowerShell we generally use PascalCase instead of camelCase, so fix that
