### PR TITLE
Remove plugins dir from path

### DIFF
--- a/CCStopper.bat
+++ b/CCStopper.bat
@@ -1,6 +1,6 @@
 @echo off
 title CCStopper
-cd /D "%~dp0"
+cd /d "%~dp0"
 set "Path=%Path%;%CD%;"
 mode con: cols=99 lines=35
 

--- a/CCStopper.bat
+++ b/CCStopper.bat
@@ -1,7 +1,7 @@
 @echo off
 title CCStopper
 cd /D "%~dp0"
-set "Path=%Path%;%CD%;%CD%\Plugins;"
+set "Path=%Path%;%CD%;"
 mode con: cols=99 lines=35
 
 :: Main script

--- a/scripts/AcrobatFix.bat
+++ b/scripts/AcrobatFix.bat
@@ -24,7 +24,7 @@ if %ERRORLEVEL% EQU 1 (
 	cls
 	echo The target registry key cannot be found. Cannot proceed with Acrobat fix.
 	pause
-	exit
+	goto exit
 ) else (
 	goto mainScript
 )


### PR DESCRIPTION
* Remove plugins directory from PATH in CCStopper.bat
  * The plugins directory was removed a while ago from CCStopper, yet CCStopper.bat still tries to add it to the path at the top of the script, so fix that
 * Fix caps in a line of code in CCStopper.bat
 * Use "goto exit" instead of "exit" in a line of code in AcrobatFix.bat