### PR TITLE
Improve StopProcesses.ps1

### DIFF
--- a/scripts/StopProcesses.ps1
+++ b/scripts/StopProcesses.ps1
@@ -19,9 +19,7 @@ $Host.UI.RawUI.WindowTitle = $MyInvocation.MyCommand.Definition + "(Elevated)"
 Get-Service -DisplayName Adobe* | Stop-Service
 
 # Stop adobe processes
-$Processes = @()
 Get-Process * | Where-Object {$_.CompanyName -match "Adobe" -or $_.Path -match "Adobe"} | ForEach-Object {
-	$Processes += ,$_
 	if($_.mainWindowTitle.Length) {
 		# Process has a window
 		$ContinueStopProcess = Read-Host "There are Adobe apps open. Do you want to continue? (y/n)"

--- a/scripts/StopProcesses.ps1
+++ b/scripts/StopProcesses.ps1
@@ -23,7 +23,6 @@ Get-Process * | Where-Object {$_.CompanyName -match "Adobe" -or $_.Path -match "
 	if($_.mainWindowTitle.Length) {
 		# Process has a window
 		$ContinueStopProcess = Read-Host "There are Adobe apps open. Do you want to continue? (y/n)"
-		if($ContinueStopProcess -ne "y") { Exit }
-		Foreach($Process in $Processes) { Stop-Process $Process -Force | Out-Null }
+		if($ContinueStopProcess -eq "y") { Stop-Process $_ -Force | Out-Null }
 	}
 }

--- a/scripts/StopProcesses.ps1
+++ b/scripts/StopProcesses.ps1
@@ -26,7 +26,6 @@ Get-Process * | Where-Object {$_.CompanyName -match "Adobe" -or $_.Path -match "
 		# Process has a window
 		$ContinueStopProcess = Read-Host "There are Adobe apps open. Do you want to continue? (y/n)"
 		if($ContinueStopProcess -ne "y") { Exit }
+		Foreach($Process in $Processes) { Stop-Process $Process -Force | Out-Null }
 	}
 }
-
-Foreach($Process in $Processes) { Stop-Process $Process -Force | Out-Null }

--- a/scripts/StopProcesses.ps1
+++ b/scripts/StopProcesses.ps1
@@ -25,13 +25,13 @@ $AdobeAppRunning = $False
 Get-Process * | Where-Object {$_.CompanyName -match "Adobe" -or $_.Path -match "Adobe"} | ForEach-Object {
 	$Processes += ,$_
 	$MyShell  = New-Object -ComObject Wscript.Shell
-	if($MyShell.AppActivate($_.ProcessName) -eq "True" -or $_.ProcessName -eq "msedgewebview2" -or $_.ProcessName -eq "CEPHtmlEngine" -or $_.Path.StartsWith('C:\Program Files\WindowsApps\')) {
+	if($MyShell.AppActivate($_.ProcessName) -or $_.mainWindowTitle.Length) {
 		# Process has a window
 		$AdobeAppRunning = $True
 	}
 }
 
-if($AdobeAppRunning -eq $True) {
+if($AdobeAppRunning) {
 	$ContinueStopProcess = Read-Host "There are Adobe apps open. Do you want to continue? (y/n)"
 	if($ContinueStopProcess -ne "y") { Exit }
 }

--- a/scripts/StopProcesses.ps1
+++ b/scripts/StopProcesses.ps1
@@ -20,19 +20,13 @@ Get-Service -DisplayName Adobe* | Stop-Service
 
 # Stop adobe processes
 $Processes = @()
-$AdobeAppRunning = $False
-
 Get-Process * | Where-Object {$_.CompanyName -match "Adobe" -or $_.Path -match "Adobe"} | ForEach-Object {
 	$Processes += ,$_
 	if($_.mainWindowTitle.Length) {
 		# Process has a window
-		$AdobeAppRunning = $True
+		$ContinueStopProcess = Read-Host "There are Adobe apps open. Do you want to continue? (y/n)"
+		if($ContinueStopProcess -ne "y") { Exit }
 	}
-}
-
-if($AdobeAppRunning) {
-	$ContinueStopProcess = Read-Host "There are Adobe apps open. Do you want to continue? (y/n)"
-	if($ContinueStopProcess -ne "y") { Exit }
 }
 
 Foreach($Process in $Processes) { Stop-Process $Process -Force | Out-Null }

--- a/scripts/StopProcesses.ps1
+++ b/scripts/StopProcesses.ps1
@@ -24,8 +24,7 @@ $AdobeAppRunning = $False
 
 Get-Process * | Where-Object {$_.CompanyName -match "Adobe" -or $_.Path -match "Adobe"} | ForEach-Object {
 	$Processes += ,$_
-	$MyShell  = New-Object -ComObject Wscript.Shell
-	if($MyShell.AppActivate($_.ProcessName) -or $_.mainWindowTitle.Length) {
+	if($_.mainWindowTitle.Length) {
 		# Process has a window
 		$AdobeAppRunning = $True
 	}


### PR DESCRIPTION
- Simplify if statement that checks if a adobe app is running
  - Checks if the process's title has a length of more than 0 characters, if so, it has a visible window as hidden windows have a title with a length of 0
  - Since anything other than 0 is equal to True, we just: if($_.mainWindowTitle) {...}
- Remove redundant "-eq $True" code since the if statement can parse any boolean
- Inline few lines of code