### PR TITLE
Fix mistake and more

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ A: Please donate your time! If you have batch scripting knowledge, please look t
 
 **Issue:** Error message: `the execution of scripts is disabled on this system. Please see "get-help about_signing" for more details.` or pushing the "Remove AGS" button gives no results.
 
-Fix: Run `set-executionpolicy remotesigned` in an administrator powershell window, or manually execute the `ProcessKill.ps1` script in the scripts folder once (you can use CCStopper running the script for the first time manually). [Credit to /u/getblownaparte on Reddit for bringing this issue up](https://www.reddit.com/r/GenP/comments/ndhm94/i_made_a_script_to_stop_all_adobe_background/gyb0twq?utm_source=share&utm_medium=web2x&context=3)
+Fix: Run `Set-ExecutionPolicy RemoteSigned` in an administrator powershell window, or manually execute the `ProcessKill.ps1` script in the scripts folder once (you can use CCStopper running the script for the first time manually). [Credit to /u/getblownaparte on Reddit for bringing this issue up](https://www.reddit.com/r/GenP/comments/ndhm94/i_made_a_script_to_stop_all_adobe_background/gyb0twq?utm_source=share&utm_medium=web2x&context=3)
 
 ---
 

--- a/scripts/AcrobatFix.bat
+++ b/scripts/AcrobatFix.bat
@@ -83,7 +83,6 @@ if errorlevel 1 (
 reg add "HKLM\Software\WOW6432Node\Adobe\Adobe Acrobat\DC\Activation" /v IsAMTEnforced /t REG_DWORD /d 1 /f /reg:64
 reg delete "HKLM\Software\WOW6432Node\Adobe\Adobe Acrobat\DC\Activation" /v IsNGLEnforced /f /reg:64
 goto restartAsk
-pause
 
 :restartAsk
 cls

--- a/scripts/BlockProcesses.bat
+++ b/scripts/BlockProcesses.bat
@@ -12,7 +12,9 @@ setlocal EnableDelayedExpansion
 for /f "usebackq delims=" %%a in (`reg query "HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall"`) do (
 	set key=%%a
 	for %%f in (!key!) do set keyName=%%~nxf
-	if "!keyName:~0,5!" equ "PHSP_" set psAppLocation=!key!
+	if "!keyName:~0,5!" equ "PHSP_" (
+		for /f "usebackq tokens=3*" %%A IN (`reg query !key! /v InstallLocation`) do set psAppLocation=%%A %%B
+	)
 )
 setlocal DisableDelayedExpansion
 

--- a/scripts/BlockProcesses.bat
+++ b/scripts/BlockProcesses.bat
@@ -7,7 +7,14 @@ mode con: cols=100 lines=42
 cd /d "%~dp0"
 
 :: Thanks to Verix#2020, from GenP Discord.
-for /f "usebackq tokens=3*" %%A IN (`reg query "HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\PHSP_23_3" /v InstallLocation`) do set psAppLocation=%%A %%B
+
+setlocal EnableDelayedExpansion
+for /f "usebackq delims=" %%a in (`reg query "HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall"`) do (
+	set key=%%a
+	for %%f in (!key!) do set keyName=%%~nxf
+	if "!keyName:~0,5!" equ "PHSP_" set psAppLocation=!key!
+)
+setlocal DisableDelayedExpansion
 
 set file1="C:\Program Files (x86)\Adobe\Adobe Sync\CoreSync\CoreSync.exe"
 set file2="C:\Program Files\Adobe\Adobe Creative Cloud Experience\CCXProcess.exe"
@@ -22,14 +29,16 @@ set blockedExists=false
 
 :: Check if files are already blocked
 :blockedCheck
-setlocal EnableDelayedExpansion
 for %%a in (%files%) do (
-	set "_=%%a" & set blocked=!_:.exe=.exe.blocked!
-	if exist !blocked! (
+	icacls "C:\Program Files (x86)\Common Files\Adobe\Adobe Desktop Common\ADS\Adobe Desktop Service.exe" | findstr "BUILTIN\Administrators:(F)"
+	if errorlevel 1 (
+		@REM WILL TRIGGER IF FILE DOESN'T EXIST!!!!!!!!!!
 		set blockedExists=true
 	)
+	if errorlevel 0 (
+		set targetExists=true	
+	)
 )
-setlocal DisableDelayedExpansion
 
 if %blockedExists% == true (
 	cls
@@ -42,12 +51,12 @@ if %blockedExists% == true (
 	echo                  ^|                        BlockProcesses Module                  ^|
 	echo                  ^|      ___________________________________________________      ^|
 	echo                  ^|                                                               ^|
-	echo                  ^|                ADOBE FILES ARE ALREADY BLOCKED!               ^|
+	echo                  ^|                ADOBE PROCESSES ARE ALREADY BLOCKED!           ^|
 	echo                  ^|                                                               ^|
 	echo                  ^|             Would you like to restore those files?            ^|
 	echo                  ^|      ___________________________________________________      ^|
 	echo                  ^|                                                               ^|
-	echo                  ^|      [1] Restore Adobe files                                  ^|
+	echo                  ^|      [1] Restore Adobe processes                              ^|
 	echo                  ^|      ___________________________________________________      ^|
 	echo                  ^|                                                               ^|
 	echo                  ^|      [Q] Exit Module                                          ^|
@@ -62,26 +71,15 @@ if %blockedExists% == true (
 	if errorlevel 1 (
 		goto mainScript
 	)
-) else (
-	goto targetCheck
 )
-
-:: Check if target path exists
-:targetCheck
-for %%a in (%files%) do (
-	if exist %%a (
-		set targetExists=true	
-	)
-)
-
 if %targetExists% == true (
 	goto mainScript
-) else (
-	cls
-	echo The target file cannot be found. Cannot proceed with blocking adobe files.
-	pause
-	goto exit
 )
+
+cls
+echo The target file cannot be found. Cannot proceed with blocking adobe files.
+pause
+goto exit
 
 :exit
 start cmd /k %~dp0\..\CCStopper.bat
@@ -89,20 +87,13 @@ exit
 
 :mainScript
 Powershell -ExecutionPolicy RemoteSigned -File .\StopProcesses.ps1
-setlocal EnableDelayedExpansion
 for %%a in (%files%) do (
-	set "_=%%a" & set blocked=!_:.exe=.exe.blocked!
-
-	for %%f in (%%a) do set name="%%~nxf"
-	for %%f in (!blocked!) do set blockedName="%%~nxf"
-	
 	if %targetExists% == true (
-		rename %%a !blockedName! >nul 2>&1
+		icacls %%a /deny Administrators:(F)
 	) else if %blockedExists% == true (
-		rename !blocked! !name! >nul 2>&1
+		icacls %%a /grant Administrators:(F)
 	)
 )
-setlocal DisableDelayedExpansion
 goto done
 
 :done

--- a/scripts/BlockProcesses.bat
+++ b/scripts/BlockProcesses.bat
@@ -26,22 +26,22 @@ set file5="%psAppLocation%\LogTransport2.exe"
 set file6="C:\Program Files (x86)\Adobe\Acrobat DC\Acrobat\AdobeCollabSync.exe"
 set files=%file1% %file2% %file3% %file4% %file5% %file6%
 
-set targetExists=false
-set blockedExists=false
+set isNotBlocked=false
+set isBlocked=false
 
 :: Check if files are already blocked
 :blockedCheck
 for %%a in (%files%) do (
 	icacls "C:\Program Files (x86)\Common Files\Adobe\Adobe Desktop Common\ADS\Adobe Desktop Service.exe" | findstr "BUILTIN\Administrators:(F)"
 	if errorlevel 1 (
-		if exist %%a set blockedExists=true
+		if exist %%a set isBlocked=true
 	)
 	if errorlevel 0 (
-		set targetExists=true	
+		set isNotBlocked=true	
 	)
 )
 
-if %blockedExists% == true (
+if %isBlocked% == true (
 	cls
 	echo:
 	echo:
@@ -73,7 +73,7 @@ if %blockedExists% == true (
 		goto mainScript
 	)
 )
-if %targetExists% == true (
+if %isNotBlocked% == true (
 	goto mainScript
 )
 
@@ -89,9 +89,9 @@ exit
 :mainScript
 Powershell -ExecutionPolicy RemoteSigned -File .\StopProcesses.ps1
 for %%a in (%files%) do (
-	if %targetExists% == true (
+	if %isNotBlocked% == true (
 		icacls %%a /deny Administrators:(F)
-	) else if %blockedExists% == true (
+	) else if %isBlocked% == true (
 		icacls %%a /grant Administrators:(F)
 	)
 )

--- a/scripts/BlockProcesses.bat
+++ b/scripts/BlockProcesses.bat
@@ -34,8 +34,7 @@ set blockedExists=false
 for %%a in (%files%) do (
 	icacls "C:\Program Files (x86)\Common Files\Adobe\Adobe Desktop Common\ADS\Adobe Desktop Service.exe" | findstr "BUILTIN\Administrators:(F)"
 	if errorlevel 1 (
-		@REM WILL TRIGGER IF FILE DOESN'T EXIST!!!!!!!!!!
-		set blockedExists=true
+		if exist %%a set blockedExists=true
 	)
 	if errorlevel 0 (
 		set targetExists=true	

--- a/scripts/DisableAutoStart.ps1
+++ b/scripts/DisableAutoStart.ps1
@@ -1,15 +1,15 @@
-$MyWindowsID=[System.Security.Principal.WindowsIdentity]::GetCurrent()
-$MyWindowsPrincipal=New-Object System.Security.Principal.WindowsPrincipal($MyWindowsID)
-$AdminRole=[System.Security.Principal.WindowsBuiltInRole]::Administrator
+$MyWindowsID = [System.Security.Principal.WindowsIdentity]::GetCurrent()
+$MyWindowsPrincipal = New-Object System.Security.Principal.WindowsPrincipal($MyWindowsID)
+$AdminRole = [System.Security.Principal.WindowsBuiltInRole]::Administrator
 
 if($MyWindowsPrincipal.IsInRole($AdminRole)) {
 $Host.UI.RawUI.WindowTitle = $MyInvocation.MyCommand.Definition + "(Elevated)"
    Clear-Host
 } else {
-   $NewProcess = New-Object System.Diagnostics.ProcessStartInfo "PowerShell";
-   $NewProcess.Arguments = $MyInvocation.MyCommand.Definition;
-   $NewProcess.Verb = "runas";
-   [System.Diagnostics.Process]::Start($newProcess);
+   $NewProcess = New-Object System.Diagnostics.ProcessStartInfo "PowerShell"
+   $NewProcess.Arguments = $MyInvocation.MyCommand.Definition
+   $NewProcess.Verb = "runas"
+   [System.Diagnostics.Process]::Start($newProcess)
    exit
 }
 

--- a/scripts/HideTrialBanner.ps1
+++ b/scripts/HideTrialBanner.ps1
@@ -1,26 +1,30 @@
-$MyWindowsID=[System.Security.Principal.WindowsIdentity]::GetCurrent()
-$MyWindowsPrincipal=New-Object System.Security.Principal.WindowsPrincipal($MyWindowsID)
-$AdminRole=[System.Security.Principal.WindowsBuiltInRole]::Administrator
+$MyWindowsID = [System.Security.Principal.WindowsIdentity]::GetCurrent()
+$MyWindowsPrincipal = New-Object System.Security.Principal.WindowsPrincipal($MyWindowsID)
+$AdminRole = [System.Security.Principal.WindowsBuiltInRole]::Administrator
 
 if($MyWindowsPrincipal.IsInRole($AdminRole)) {
 $Host.UI.RawUI.WindowTitle = $MyInvocation.MyCommand.Definition + "(Elevated)"
    Clear-Host
 } else {
-   $NewProcess = New-Object System.Diagnostics.ProcessStartInfo "PowerShell";
-   $NewProcess.Arguments = $MyInvocation.MyCommand.Definition;
-   $NewProcess.Verb = "runas";
-   [System.Diagnostics.Process]::Start($newProcess);
+   $NewProcess = New-Object System.Diagnostics.ProcessStartInfo "PowerShell"
+   $NewProcess.Arguments = $MyInvocation.MyCommand.Definition
+   $NewProcess.Verb = "runas"
+   [System.Diagnostics.Process]::Start($newProcess)
    exit
 }
 
-$PsAppLocation = (Get-ItemProperty -Path "HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\PHSP_23_3").InstallLocation
-$AiAppLocation = (Get-ItemProperty -Path "HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\ILST_26_2_1").InstallLocation
+function Get-UninstallKey ([String]$ID) {
+	return (Get-ChildItem HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall -Recurse | Where-Object {$_.PSChildName -Like "$ID_*"}).Name
+}
+
+$PSAppLocation = (Get-ItemProperty -Path Registry::$(Get-UninstallKey -ID "PHSP") -Name InstallLocation)
+$AIAppLocation = (Get-ItemProperty -Path Registry::$(Get-UninstallKey -ID "ILST") -Name InstallLocation)
 $Button = $Shell.Popup($AppLocation, 0, "Trial Banner Hider", 0)
 
-
-$StylePath = 'C:\Program Files\Common Files\Adobe\UXP\extensions\com.adobe.ccx.start-5.9.0\css\styles.css'
-$StylePath1 = "$($PsAppLocation)\Required\UXP\com.adobe.ccx.start\css\styles.css"
-$StylePath2 = "$($AiAppLocation)\Support Files\Required\UXP\extensions\com.adobe.ccx.start\css\styles.css"
+$CommonExtensions = 'C:\Program Files\Common Files\Adobe\UXP\extensions'
+$StylePath = "$CommonExtensions\$((Get-ChildItem $CommonExtensions -Recurse | Where-Object {$_.PSChildName -Like 'com.adobe.ccx.start-*'}).Name)\css\styles.css"
+$StylePath1 = "$($PSAppLocation)\Required\UXP\com.adobe.ccx.start\css\styles.css"
+$StylePath2 = "$($AIAppLocation)\Support Files\Required\UXP\extensions\com.adobe.ccx.start\css\styles.css"
 $LocalePath = 'C:\Program Files (x86)\Common Files\Adobe\AdobeGCClient\locales'
 
 $Style_None = '{"display":"none"}'
@@ -41,7 +45,7 @@ $Style_TrialEnded = '{"background-color":"#d7373f"}'
 
 # Delete Language Packs
 $ErrorActionPreference= 'silentlycontinue'
-Remove-Item '$LocalePath' -Force -Recurse
+Remove-Item "$LocalePath" -Force -Recurse
 
 $Shell = New-Object -ComObject "WScript.Shell"
-$Button = $Shell.Popup("Trial banner has been hidden!", 0, "Trial Banner Hider", 0)
+$Shell.Popup("Trial banner has been hidden!", 0, "Trial Banner Hider", 0)

--- a/scripts/StopProcesses.ps1
+++ b/scripts/StopProcesses.ps1
@@ -1,15 +1,15 @@
-$MyWindowsID=[System.Security.Principal.WindowsIdentity]::GetCurrent()
-$MyWindowsPrincipal=New-Object System.Security.Principal.WindowsPrincipal($MyWindowsID)
-$AdminRole=[System.Security.Principal.WindowsBuiltInRole]::Administrator
+$MyWindowsID = [System.Security.Principal.WindowsIdentity]::GetCurrent()
+$MyWindowsPrincipal = New-Object System.Security.Principal.WindowsPrincipal($MyWindowsID)
+$AdminRole = [System.Security.Principal.WindowsBuiltInRole]::Administrator
 
 if($MyWindowsPrincipal.IsInRole($AdminRole)) {
 $Host.UI.RawUI.WindowTitle = $MyInvocation.MyCommand.Definition + "(Elevated)"
    Clear-Host
 } else {
-   $NewProcess = New-Object System.Diagnostics.ProcessStartInfo "PowerShell";
-   $NewProcess.Arguments = $MyInvocation.MyCommand.Definition;
-   $NewProcess.Verb = "runas";
-   [System.Diagnostics.Process]::Start($newProcess);
+   $NewProcess = New-Object System.Diagnostics.ProcessStartInfo "PowerShell"
+   $NewProcess.Arguments = $MyInvocation.MyCommand.Definition
+   $NewProcess.Verb = "runas"
+   [System.Diagnostics.Process]::Start($newProcess)
    exit
 }
 

--- a/scripts/StopProcesses.ps1
+++ b/scripts/StopProcesses.ps1
@@ -19,10 +19,14 @@ $Host.UI.RawUI.WindowTitle = $MyInvocation.MyCommand.Definition + "(Elevated)"
 Get-Service -DisplayName Adobe* | Stop-Service
 
 # Stop adobe processes
+$Processes = @()
 Get-Process * | Where-Object {$_.CompanyName -match "Adobe" -or $_.Path -match "Adobe"} | ForEach-Object {
+	$Processes += ,$_
 	if($_.mainWindowTitle.Length) {
 		# Process has a window
 		$ContinueStopProcess = Read-Host "There are Adobe apps open. Do you want to continue? (y/n)"
-		if($ContinueStopProcess -eq "y") { Stop-Process $_ -Force | Out-Null }
+		if($ContinueStopProcess -ne "y") { Exit }
 	}
 }
+
+Foreach($Process in $Processes) { Stop-Process $Process -Force | Out-Null }


### PR DESCRIPTION
 - Fix a mistake done while cleaning up code in StopProcesses.ps1

Also does the following things:
 - Improve the "Ask for admin" code block in powershell scripts
 - Autodetect version of com.adobe.ccx.start folder instead of explicitly specifying version in HideTrialBanner.ps1
 - Make the psAppLocation and aiAppLocation variable autodetect the ps & ai version instead of explicitly specifying version in HideTrialBanner.ps1 and BlockProcesses.bat
 - Use Name argument for Get-ItemProperty to get the InstallLocation value instead of accessing it as a property of the ItemProperty object
 - Remove access permissions from process files instead of renaming in BlockProcesses.bat
